### PR TITLE
fix: restrict Gmail credential mount to main group only

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -164,15 +164,18 @@ function buildVolumeMounts(
     readonly: false,
   });
 
-  // Gmail credentials directory (for Gmail MCP inside the container)
-  const homeDir = os.homedir();
-  const gmailDir = path.join(homeDir, '.gmail-mcp');
-  if (fs.existsSync(gmailDir)) {
-    mounts.push({
-      hostPath: gmailDir,
-      containerPath: '/home/node/.gmail-mcp',
-      readonly: false, // MCP may need to refresh OAuth tokens
-    });
+  // Gmail credentials directory — main group only (non-main groups
+  // should not have access to the owner's email account).
+  if (isMain) {
+    const homeDir = os.homedir();
+    const gmailDir = path.join(homeDir, '.gmail-mcp');
+    if (fs.existsSync(gmailDir)) {
+      mounts.push({
+        hostPath: gmailDir,
+        containerPath: '/home/node/.gmail-mcp',
+        readonly: false, // MCP may need to refresh OAuth tokens
+      });
+    }
   }
 
   // Per-group IPC namespace: each group gets its own IPC directory


### PR DESCRIPTION
## Summary
- Gmail OAuth credentials (`~/.gmail-mcp`) were mounted into **all** group containers, not just the main group
- Non-main group agents could read/send email using the owner's Gmail account, breaking sandbox isolation
- Wraps the mount block in an `if (isMain)` guard (the parameter is already available in `buildVolumeMounts`)